### PR TITLE
Fix bug

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -14,6 +14,7 @@ use craft\events\RegisterElementTableAttributesEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\SetElementTableAttributeHtmlEvent;
 use craft\helpers\UrlHelper;
+use craft\services\Plugins;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use dukt\social\base\PluginTrait;
@@ -124,7 +125,12 @@ class Plugin extends \craft\base\Plugin
             }
         });
 
-        $this->initCpSocialLogin();
+        Event::on(
+            Plugins::class,
+            Plugins::EVENT_AFTER_LOAD_PLUGINS,
+            function() {
+                $this->initCpSocialLogin();
+        });
         $this->initLoginAccountsUserPane();
     }
 

--- a/src/records/LoginAccount.php
+++ b/src/records/LoginAccount.php
@@ -32,7 +32,7 @@ class LoginAccount extends ActiveRecord
      */
     public static function tableName(): string
     {
-        return 'social_login_accounts';
+        return '{{%social_login_accounts}}';
     }
 
     /**


### PR DESCRIPTION
To recreate the issue, consider the scenario where we register third party providers using `LoginProviders::EVENT_REGISTER_LOGIN_PROVIDER_TYPES` in our plugin's `init()` function.

Social plugin will call `initCpSocialLogin()` in its  own `init()` and in that function, all the available providers will get used to generate the javascript code. However, at this point of time, it is not guaranteed that the provider has been registered.

To fix it, we just call this function after all other plugins have finished their `init()`.