### PR TITLE
Don't delete existing user photo before replacing

### DIFF
--- a/src/services/LoginAccounts.php
+++ b/src/services/LoginAccounts.php
@@ -307,10 +307,6 @@ class LoginAccounts extends Component
 
         rename($tempPath.$filename, $tempPath.$filename.'.'.$extension);
 
-        if ($user->photoId) {
-            Craft::$app->users->deleteUserPhoto($user);
-        }
-
         $image = Craft::$app->images->loadImage($tempPath.$filename.'.'.$extension);
         $imageWidth = $image->getWidth();
         $imageHeight = $image->getHeight();


### PR DESCRIPTION
There's no need to delete the existing user photo since Craft handles this situation itself in craft\services\Users::saveUserPhoto:

```
// If the photo exists, just replace the file.
        if ($user->photoId) {
            // No longer a new file.
            $assetsService->replaceAssetFile($assetsService->getAssetById($user->photoId), $fileLocation, $filenameToUse);
        } else {
        // ...
```

Also, Craft throws an error if the photo is deleted manually from beforehand, as the `if ($user->photoId)` condition still returns true (unsure why it would), but `$assetsService->getAssetById($user->photoId)` returns null.