### PR TITLE
Fixes translation category on saving

### DIFF
--- a/src/controllers/LoginProvidersController.php
+++ b/src/controllers/LoginProvidersController.php
@@ -164,12 +164,12 @@ class LoginProvidersController extends Controller
         ];
 
         if (Plugin::getInstance()->saveLoginProviderSettings($handle, $settings)) {
-            Craft::$app->getSession()->setNotice(Craft::t('analytics', 'Provider saved.'));
+            Craft::$app->getSession()->setNotice(Craft::t('social', 'Provider saved.'));
 
             return $this->redirectToPostedUrl();
         }
 
-        Craft::$app->getSession()->setError(Craft::t('analytics', 'Couldn’t save provider.'));
+        Craft::$app->getSession()->setError(Craft::t('social', 'Couldn’t save provider.'));
 
         return null;
     }


### PR DESCRIPTION
This pull request is fixing the mistyped translation category in the controller which drops an exception after saving changes on a provider in the backend area.

Also fixes the issue described at https://github.com/dukt/social/issues/13