### PR TITLE
Check if DB table exists before creating.

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -79,6 +79,7 @@ class Install extends Migration
      */
     protected function createTables()
     {
+      if (!$this->db->tableExists('{{%social_login_accounts}}')) {
         $this->createTable(
             '{{%social_login_accounts}}',
             [
@@ -93,6 +94,7 @@ class Install extends Migration
                 'PRIMARY KEY(id)',
             ]
         );
+      }
     }
 
     /**


### PR DESCRIPTION
If the database table already exists you can't install the plugin without deleting the table and wiping any existing data, to get around this I am just checking if the table already exists before creating it in the install migration.